### PR TITLE
add required name attribute

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             'apache'
 maintainer       'Brian Webb'
 maintainer_email 'bwebb@indatus.com'
 description       "Configures apache"


### PR DESCRIPTION
metadata.rb now has a required `name` attribute
